### PR TITLE
Add public holidays in Turkey

### DIFF
--- a/holiday_library/holiday_defs/public_holiday/tur/tur.xml
+++ b/holiday_library/holiday_defs/public_holiday/tur/tur.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="tur">
+	<metadata>
+		<reference>https://www.mevzuat.gov.tr/MevzuatMetin/1.5.2429.pdf</reference>
+	</metadata>
+	
+	<!-- current dates -->
+	<holiday validFrom="1935-01-01">
+		<date>
+			<fixedDate day="1" month="1" />
+		</date>
+		<name lang="tr">Yılbaşı</name>
+		<name lang="en">New Year's Day</name>
+		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
+	
+	<holiday validFrom="1921-01-01">
+		<date>
+			<fixedDate day="23" month="4" />
+		</date>
+		<name lang="tr">Ulusal Egemenlik ve Çocuk Bayramı</name>
+		<name lang="en">National Sovereignty and Children's Day</name>
+		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
+	
+	<holiday validFrom="2009-01-01">
+		<date>
+			<fixedDate day="1" month="5" />
+		</date>
+		<name lang="tr">Emek ve Dayanışma Günü</name>
+		<name lang="en">Labour and Solidarity Day</name>
+		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
+	
+	<holiday validFrom="1935-01-01">
+		<date>
+			<fixedDate day="19" month="5" />
+		</date>
+		<name lang="tr">Atatürk'ü Anma Gençlik ve Spor Bayramı</name>
+		<name lang="en">Commemoration of Atatürk, Youth and Sports Day</name>
+		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
+	
+	<holiday validFrom="2017-01-01">
+		<date>
+			<fixedDate day="15" month="7" />
+		</date>
+		<name lang="tr">Demokrasi ve Millî Birlik Günü</name>
+		<name lang="en">Democracy and National Unity Day</name>
+		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
+	
+	<holiday validFrom="1935-01-01">
+		<date>
+			<fixedDate day="30" month="8" />
+		</date>
+		<name lang="tr">Zafer Bayramı</name>
+		<name lang="en">Victory Day</name>
+		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
+	
+	<holiday validFrom="1925-01-01">
+		<date>
+			<fixedDate day="29" month="10" />
+		</date>
+		<name lang="tr">Cumhuriyet Bayramı</name>
+		<name lang="en">Republic Day</name>
+		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
+
+	<holiday validFrom="1909-01-01">
+		<date>
+			<dateTransformation>
+				<baseDate>
+					<specialDate>HIJRI_MONTH_10TH_START</specialDate>
+				</baseDate>
+				<addDays>9</addDays>
+			</dateTransformation>
+		</date>
+		<dateTo>
+			<dateTransformation>
+				<baseDate>
+					<specialDate>HIJRI_MONTH_10TH_START</specialDate>
+				</baseDate>
+				<addDays>11</addDays>
+			</dateTransformation>
+		</date>
+		<name lang="tr">Ramazan Bayramı</name>
+		<name lang="en">Eid al-Fitr</name>
+	</holiday>
+
+	<holiday validFrom="1909-01-01">
+		<date>
+			<specialDate>HIJRI_MONTH_12TH_START</specialDate>
+		</date>
+		<dateTo>
+			<dateTransformation>
+				<baseDate>
+					<specialDate>HIJRI_MONTH_12TH_START</specialDate>
+				</baseDate>
+				<addDays>3</addDays>
+			</dateTransformation>
+		</date>
+		<name lang="tr">Kurban Bayramı</name>
+		<name lang="en">Eid al-Adha</name>
+	</holiday>
+
+	<!-- demoted dates -->
+	<holiday validFrom="1963-01-01" validTo="1981-12-31">
+		<date>
+			<fixedDate day="25" month="6" />
+		</date>
+		<name lang="tr">Anayasa Bayramı</name>
+		<name lang="en">Constitution Day</name>
+	</holiday>
+
+	<holiday validFrom="1909-01-01" validTo="1934-12-31">
+		<date>
+			<fixedDate day="8" month="10" />
+		</date>
+		<name lang="tr">İyd-i Millî</name>
+		<name lang="en">National Day</name>
+	</holiday>		
+</holidays>


### PR DESCRIPTION
For information besides the turkish law cited, see also https://en.wikipedia.org/wiki/Public_holidays_in_Turkey.

All public holidays start on 13:00 of the previous day. I have not entered that as additional PART_DAY_HOLIDAY, because it is also true for the weekend: as defined by law 2429, it also starts on Saturday 13:00.

The one provision I am not sure I got right is: Holidays ending on Friday are prolonged to include Saturday. Please review.