### PR TITLE
Add Christmas Holiday on 26 Dec 2022 in Spain

### DIFF
--- a/holiday_library/holiday_defs/observance/esp/an/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/an/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/observance/esp/ar/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/ar/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/observance/esp/cb/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/cb/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/observance/esp/cl/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/cl/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/observance/esp/cm/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/cm/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/observance/esp/cn/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/cn/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/observance/esp/ex/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/ex/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/observance/esp/mc/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/mc/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/observance/esp/md/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/md/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/observance/esp/ml/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/ml/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/observance/esp/nc/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/nc/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/observance/esp/ri/2022.xml
+++ b/holiday_library/holiday_defs/observance/esp/ri/2022.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="esp">
+	<metadata>
+		<reference>https://publicholidays.es/2022-dates/</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="26" month="12" />
+		</date>
+		<name lang="es">Feriado de Navidad</name>
+		<name lang="en">Christmas Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/public_holiday/esp/esp.xml
+++ b/holiday_library/holiday_defs/public_holiday/esp/esp.xml
@@ -89,7 +89,6 @@
 		</date>
 		<name lang="es">Navidad</name>
 		<name lang="en">Christmas Day</name>
-		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
 
 </holidays>


### PR DESCRIPTION
Enrico displayed Christmas Day on 26 Dec 2022 (Holiday in lieu of 25 Dec
2022 because 25 Dec is Sunday). This was incorrect because Christmas Day
is still a national holiday with fixed date 25 Dec. There's an
additional Christmas Holiday on Monday, 26 Dec 2022, but only in some
regions of Spain.

See also: https://publicholidays.es/2022-dates/