### PR TITLE
Juneteenth support

### DIFF
--- a/holiday_library/holiday_defs/public_holiday/usa/ak/ak.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ak/ak.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.library.state.ak.us/akholidays.html</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,35 +11,38 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="3" nth="last" />
 		</date>
 		<name lang="en">Seward's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -50,14 +51,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="18" month="10" />
@@ -66,7 +65,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -75,14 +73,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -91,5 +87,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/al/al.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/al/al.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://personnel.alabama.gov/Downloads/StateHolidays.pdf</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Robert E. Lee, Martin Luther King, Jr.'s Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">George Washington, Thomas Jefferson's Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -41,28 +36,32 @@
 		<flag>REGIONAL_HOLIDAY</flag>
 		<note lang="en">Observed only in Baldwin and Mobile Counties</note>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="4" nth="4" />
 		</date>
 		<name lang="en">Confederate Memorial Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">National Memorial Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="6" nth="1" />
 		</date>
 		<name lang="en">Jefferson Davis' Birthday</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -71,21 +70,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day, Fraternal Day, American Indian Heritage Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -94,21 +90,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2019-01-01">
 		<date>
 			<fixedDate day="1" month="12" />
 		</date>
 		<name lang="en">Mrs. Rosa L. Parks Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -117,5 +110,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ar/ar.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ar/ar.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.sos.arkansas.gov/aboutOffice/Pages/stateHolidayCalendar.aspx</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Dr. Martin Luther King Jr. and Robert E. Lee’s Birthdays</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">George Washington’s Birthday and Daisy Gatson Bates Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,14 +45,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -59,14 +59,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="24" month="12" />
@@ -76,7 +74,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -86,5 +83,4 @@
 		<observanceRule dayOfWeek="1" addDays="1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/az/az.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/az/az.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://hr.az.gov/content/state-employee-resources</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Dr. Martin Luther King, Jr. / Civil Rights Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Lincoln / Washington / Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,21 +45,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -66,14 +65,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -82,5 +79,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ca/ca.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ca/ca.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.calhr.ca.gov/employees/Pages/state-holidays.aspx</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -12,21 +10,18 @@
 		<name lang="en">New Year's Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="31" month="3" />
@@ -34,14 +29,20 @@
 		<name lang="en">Cesar Chavez Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -49,14 +50,12 @@
 		<name lang="en">Independence Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -65,14 +64,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -84,7 +81,6 @@
 		</date>
 		<name lang="en">Day after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -92,5 +88,4 @@
 		<name lang="en">Christmas Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/co/co.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/co/co.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://holidays.uslegal.com/state-holidays/colorado-legal-holidays/</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr.'s Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Washington-Lincoln Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,21 +45,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -66,14 +65,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -82,5 +79,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ct/ct.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ct/ct.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.ct.gov/dob/cwp/view.asp?a=2226&amp;q=465152</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,14 +11,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="12" month="2" />
@@ -29,14 +25,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Washington's Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -48,14 +42,20 @@
 		</date>
 		<name lang="en">Good Friday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -64,21 +64,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -87,14 +84,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -103,5 +98,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/dc/dc.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/dc/dc.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://dchr.dc.gov/page/holiday-schedules</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr.'s Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Washington's Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="16" month="4" />
@@ -36,14 +31,20 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -52,21 +53,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Indigenous Peoples' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -75,14 +73,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -91,5 +87,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/de/de.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/de/de.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://dhr.delaware.gov/labor/holidays/index.shtml</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,14 +11,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -32,14 +28,20 @@
 		</date>
 		<name lang="en">Good Friday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -48,14 +50,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="2%0">
 		<date>
 			<dateTransformation>
@@ -67,7 +67,6 @@
 		</date>
 		<name lang="en">Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="2%0">
 		<date>
 			<dateTransformation>
@@ -82,7 +81,6 @@
 		<flag>PART_DAY_HOLIDAY</flag>
 		<note lang="en">Observed only in Sussex County (after 12:00 noon)</note>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -91,14 +89,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -110,7 +106,6 @@
 		</date>
 		<name lang="en">Day after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -119,5 +114,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/fl/fl.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/fl/fl.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www.dms.myflorida.com/workforce_operations/human_resource_management/for_state_personnel_system_hr_practitioners/state_holidays</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,26 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Birthday of Dr. Martin Luther King, Jr.</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -36,14 +39,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -52,14 +53,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -71,7 +70,6 @@
 		</date>
 		<name lang="en">Day after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -80,5 +78,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ga/ga.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ga/ga.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://georgia.gov/popular-topic/finding-state-holidays</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,26 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr.'s Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2020-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -36,21 +39,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2018-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -59,14 +59,12 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -78,7 +76,6 @@
 		</date>
 		<name lang="en">State Holiday</name>
 	</holiday>
-	
 	<holiday validFrom="2012-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -87,15 +84,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
-	<!-- old holidays -->
 	<holiday validFrom="2011-01-01" validTo="2019-12-31">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="4" nth="4" />
 		</date>
 		<name lang="en">Confederate Memorial Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" validTo="2014-12-31">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -104,7 +98,6 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2016-01-01" validTo="2019-12-31">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -113,7 +106,6 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" validTo="2016-12-31">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -122,5 +114,4 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/hi/hi.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/hi/hi.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://dhrd.hawaii.gov/state-observed-holidays/</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Dr. Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="26" month="3" />
@@ -36,7 +31,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -48,14 +42,12 @@
 		</date>
 		<name lang="en">Good Friday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="6" />
@@ -64,7 +56,14 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -73,21 +72,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="5" month="8" nth="3" />
 		</date>
 		<name lang="en">Statehood Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="2%0">
 		<date>
 			<dateTransformation>
@@ -99,7 +95,6 @@
 		</date>
 		<name lang="en">General Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -108,14 +103,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -124,5 +117,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ia/ia.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ia/ia.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://das.iowa.gov/das-core/customer-service-center/state-holidays</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,26 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Dr. Martin Luther King, Jr.’s Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -36,14 +39,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -52,14 +53,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -71,7 +70,6 @@
 		</date>
 		<name lang="en">Day after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -80,5 +78,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/id/id.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/id/id.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www.idaho.gov/government/state-holidays/</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr./Idaho Human Rights Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,21 +45,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -66,14 +65,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -82,5 +79,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/il/il.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/il/il.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www2.illinois.gov/cms/personnel/employeeresources/Pages/StateHolidays.aspx</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,14 +11,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="12" month="2" />
@@ -29,21 +25,26 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Washington's Birthday (President's Day)</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -52,14 +53,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="2%0">
 		<date>
 			<dateTransformation>
@@ -71,14 +70,12 @@
 		</date>
 		<name lang="en">General Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -87,14 +84,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -106,7 +101,6 @@
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -115,5 +109,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/in/in.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/in/in.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.in.gov/spd/2555.htm</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,14 +11,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -32,7 +28,6 @@
 		</date>
 		<name lang="en">Good Friday</name>
 	</holiday>
-	
 	<holiday validFrom="2018-01-01">
 		<date>
 			<dateTransformation>
@@ -44,14 +39,20 @@
 		</date>
 		<name lang="en">Primary Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -60,21 +61,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2018-01-01">
 		<date>
 			<dateTransformation>
@@ -86,7 +84,6 @@
 		</date>
 		<name lang="en">General Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -95,14 +92,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -114,7 +109,6 @@
 		</date>
 		<name lang="en">Lincoln's Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2015-01-01">
 		<date>
 			<fixedDate day="24" month="12" />
@@ -124,7 +118,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -134,8 +127,6 @@
 		<observanceRule dayOfWeek="1" addDays="1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
-	<!-- Old holidays -->
 	<holiday validFrom="2011-01-01" validTo="2012-12-31">
 		<date>
 			<dateTransformation>
@@ -147,7 +138,6 @@
 		</date>
 		<name lang="en">Primary Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2014-01-01" validTo="2016-12-31">
 		<date>
 			<dateTransformation>
@@ -159,7 +149,6 @@
 		</date>
 		<name lang="en">Primary Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" validTo="2012-12-31">
 		<date>
 			<dateTransformation>
@@ -171,7 +160,6 @@
 		</date>
 		<name lang="en">General Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2014-01-01" validTo="2016-12-31">
 		<date>
 			<dateTransformation>
@@ -183,7 +171,6 @@
 		</date>
 		<name lang="en">General Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" validTo="2013-12-31">
 		<date>
 			<fixedDate day="24" month="12" />

--- a/holiday_library/holiday_defs/public_holiday/usa/ks/ks.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ks/ks.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.da.ks.gov/ps/subject/holiday.htm</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,26 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -36,14 +39,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -52,14 +53,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -71,7 +70,6 @@
 		</date>
 		<name lang="en">Day after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -80,5 +78,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ky/ky.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ky/ky.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://personnel.ky.gov/Pages/Leave.aspx</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -14,14 +12,12 @@
 		<observanceRule dayOfWeek="1" addDays="1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr.'s Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -35,14 +31,20 @@
 		<flag>PART_DAY_HOLIDAY</flag>
 		<note lang="en">One-half day</note>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -51,14 +53,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="4%0">
 		<date>
 			<dateTransformation>
@@ -70,7 +70,6 @@
 		</date>
 		<name lang="en">Presidential Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -79,14 +78,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -98,7 +95,6 @@
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2015-01-01">
 		<date>
 			<fixedDate day="24" month="12" />
@@ -108,7 +104,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -118,7 +113,6 @@
 		<observanceRule dayOfWeek="1" addDays="1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2015-01-01">
 		<date>
 			<fixedDate day="31" month="12" />
@@ -128,8 +122,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
-	<!-- Old Holidays -->
 	<holiday validFrom="2011-01-01" validTo="2013-12-31">
 		<date>
 			<fixedDate day="24" month="12" />
@@ -139,7 +131,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" validTo="2013-12-31">
 		<date>
 			<fixedDate day="31" month="12" />
@@ -149,6 +140,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/la/la.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/la/la.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www.doa.la.gov/Pages/osp/aboutus/Holidays-2020.aspx</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,7 +11,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="4%0">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="2" />
@@ -22,14 +19,12 @@
 		<flag>PART_DAY_HOLIDAY</flag>
 		<note lang="en">Observed only in the City of Baton Rouge</note>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr.'s Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -41,7 +36,6 @@
 		</date>
 		<name lang="en">Good Friday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -53,14 +47,20 @@
 		</date>
 		<name lang="en">Mardi Gras</name>
 	</holiday>
-
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -69,14 +69,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="2%0">
 		<date>
 			<dateTransformation>
@@ -88,7 +86,6 @@
 		</date>
 		<name lang="en">Elections Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -97,14 +94,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -113,5 +108,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ma/ma.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ma/ma.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.sec.state.ma.us/cis/cishol/holidx.htm</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -12,35 +10,38 @@
 		<name lang="en">New Year's Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Washington’s Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="4" nth="3" />
 		</date>
 		<name lang="en">Patriots' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -48,21 +49,18 @@
 		<name lang="en">Independence Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -70,14 +68,12 @@
 		<name lang="en">Veterans' Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -85,5 +81,4 @@
 		<name lang="en">Christmas Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/md/md.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/md/md.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.msa.md.gov/msa/mdmanual/01glance/html/holidays.html</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Dr. Martin Luther King, Jr., Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,21 +45,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="4%2">
 		<date>
 			<dateTransformation>
@@ -69,7 +68,6 @@
 		</date>
 		<name lang="en">Gubernatorial Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -78,14 +76,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -97,7 +93,6 @@
 		</date>
 		<name lang="en">American Indian Heritage Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -106,5 +101,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/me/me.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/me/me.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www.maine.gov/bhr/state-employees/2020-holiday-schedule</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,35 +11,38 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Washington's Birthday/President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="4" nth="3" />
 		</date>
 		<name lang="en">Patriots Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -50,21 +51,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Indigenous Peoples Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -73,14 +71,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -92,7 +88,6 @@
 		</date>
 		<name lang="en">Thanksgiving Friday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -101,5 +96,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/mi/mi.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/mi/mi.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.michigan.gov/som/0,1607,7-192-29938-90605--,00.html</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -14,28 +12,32 @@
 		<observanceRule dayOfWeek="1" addDays="1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -44,14 +46,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="2%0">
 		<date>
 			<dateTransformation>
@@ -63,7 +63,6 @@
 		</date>
 		<name lang="en">General Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -72,14 +71,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -91,7 +88,6 @@
 		</date>
 		<name lang="en">Day after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2018-01-01">
 		<date>
 			<fixedDate day="24" month="12" />
@@ -101,7 +97,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -111,7 +106,6 @@
 		<observanceRule dayOfWeek="1" addDays="1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2018-01-01">
 		<date>
 			<fixedDate day="31" month="12" />
@@ -121,8 +115,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
-	<!-- Old dates -->
 	<holiday validFrom="2011-01-01" validTo="2016-12-31">
 		<date>
 			<fixedDate day="24" month="12" />
@@ -132,7 +124,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" validTo="2016-12-31">
 		<date>
 			<fixedDate day="31" month="12" />
@@ -142,5 +133,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/mn/mn.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/mn/mn.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www.employmentlawhandbook.com/leave-laws/state-leave-laws/minnesota/holidays/</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,21 +45,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -66,14 +65,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -85,7 +82,6 @@
 		</date>
 		<name lang="en">Day after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -94,5 +90,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/mo/mo.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/mo/mo.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://oa.mo.gov/commissioner/state-holidays</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,14 +11,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="12" month="2" />
@@ -29,14 +25,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Washington's Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="8" month="5" />
@@ -45,14 +39,20 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -61,21 +61,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -84,14 +81,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -100,5 +95,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ms/ms.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ms/ms.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www.sos.ms.gov/education-publications/pages/state-holidays.aspx</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,35 +11,38 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King's and Robert E. Lee's Birthdays</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">George Washington's Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="4" nth="last" />
 		</date>
 		<name lang="en">Confederate Memorial Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">National Memorial Day / Jefferson Davis' Birthday</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -50,14 +51,12 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -66,14 +65,12 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -82,5 +79,4 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/mt/mt.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/mt/mt.xml
@@ -1,11 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.mtcounties.org/resources/miscellaneous/montana-state-holidays</reference>
 		<reference>https://hr.mt.gov/newpayschedcals</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -14,28 +12,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -44,21 +46,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="2%0">
 		<date>
 			<dateTransformation>
@@ -70,7 +69,6 @@
 		</date>
 		<name lang="en">General Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -79,14 +77,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -95,5 +91,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/nc/nc.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/nc/nc.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.ic.nc.gov/ncic/pages/holiday.htm</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,14 +11,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -32,14 +28,20 @@
 		</date>
 		<name lang="en">Good Friday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -48,14 +50,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -64,14 +64,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -83,7 +81,6 @@
 		</date>
 		<name lang="en">Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="24" month="12" />
@@ -92,7 +89,6 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -102,5 +98,4 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="2" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/nd/nd.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/nd/nd.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://sos.nd.gov/about-office/holiday-office-closings</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -39,14 +34,20 @@
 		</date>
 		<name lang="en">Good Friday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -55,14 +56,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -71,14 +70,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -87,5 +84,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ne/ne.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ne/ne.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.das.state.ne.us/personnel/holidayschedule.htm</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,35 +11,38 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="5" month="4" nth="last" />
 		</date>
 		<name lang="en">Arbor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -50,21 +51,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -73,14 +71,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -92,7 +88,6 @@
 		</date>
 		<name lang="en">Day after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -101,5 +96,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/nh/nh.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/nh/nh.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://das.nh.gov/hr/documents/holiday-calendar-2020-sonh.pdf</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr. /Civil Rights Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">President’s Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,14 +45,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="2%0">
 		<date>
 			<dateTransformation>
@@ -63,7 +63,6 @@
 		<name lang="en">Election Day</name>
 		<note lang="en">State offices remain open</note>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -72,14 +71,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -91,7 +88,6 @@
 		</date>
 		<name lang="en">Day after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -100,5 +96,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/nj/nj.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/nj/nj.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www.state.nj.us/nj/about/facts/holidays/</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -39,14 +34,20 @@
 		</date>
 		<name lang="en">Good Friday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -55,22 +56,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -82,7 +79,6 @@
 		</date>
 		<name lang="en">Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -91,14 +87,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -107,5 +101,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/nm/nm.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/nm/nm.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.stonm.org/AboutTheTreasurersOffice/OfficialStateHolidays</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,26 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -36,21 +39,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -59,14 +59,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -78,7 +76,6 @@
 		</date>
 		<name lang="en">The Friday after Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -87,5 +84,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/nv/nv.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/nv/nv.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://hr.nv.gov/uploadedFiles/hrnvgov/Content/About/State%20Holidays.pdf</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr.'s Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,21 +45,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="5" month="10" nth="last" />
 		</date>
 		<name lang="en">Nevada Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -66,14 +65,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -85,7 +82,6 @@
 		</date>
 		<name lang="en">Family Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -94,5 +90,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ny/ny.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ny/ny.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.cs.ny.gov/attendance_leave/index.cfm#legal</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -12,14 +10,12 @@
 		<name lang="en">New Year's Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Dr. Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="12" month="2" />
@@ -27,21 +23,26 @@
 		<name lang="en">Lincoln's Birthday</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Washington's Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -49,21 +50,18 @@
 		<name lang="en">Independence Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -75,7 +73,6 @@
 		</date>
 		<name lang="en">Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -83,14 +80,12 @@
 		<name lang="en">Veterans' Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -98,5 +93,4 @@
 		<name lang="en">Christmas Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/oh/oh.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/oh/oh.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://ohio.gov/stateemployee/</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,21 +45,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -66,14 +65,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -82,5 +79,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ok/ok.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ok/ok.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://omes.ok.gov/pages/2020-official-state-holidays</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,14 +45,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -59,14 +59,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -78,7 +76,6 @@
 		</date>
 		<name lang="en">Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="24" month="12" />
@@ -87,7 +84,6 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -97,5 +93,4 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="2" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/or/or.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/or/or.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www.oregon.gov/das/Pages/Calendar.aspx</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr.’s Birthday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,14 +45,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -59,14 +59,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -78,7 +76,6 @@
 		</date>
 		<name lang="en">The Day after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -87,5 +84,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/pa/pa.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/pa/pa.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www.budget.pa.gov/Services/ForAgencies/Payroll/Pages/Holiday-and-Pay-Calendars.aspx</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Dr. Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,21 +45,18 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -66,14 +65,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -85,7 +82,6 @@
 		</date>
 		<name lang="en">The Day after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -94,5 +90,4 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ri/ri.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ri/ri.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.dlt.ri.gov/ls/holidays.htm</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -12,14 +10,20 @@
 		<name lang="en">New Year's Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -27,28 +31,24 @@
 		<name lang="en">Independence Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="8" nth="2" />
 		</date>
 		<name lang="en">Victory Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -56,14 +56,12 @@
 		<name lang="en">Armistice Day / Veteran's Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -71,5 +69,4 @@
 		<name lang="en">Christmas Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/sc/sc.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/sc/sc.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www.scdhec.gov/about-dhec/state-holidays</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr.'s Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">George Washington's Birthday/President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="10" month="5" />
@@ -36,14 +31,20 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">National Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -52,14 +53,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -68,14 +67,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -87,7 +84,6 @@
 		</date>
 		<name lang="en">The Friday after Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="24" month="12" />
@@ -96,7 +92,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -106,7 +101,6 @@
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="1" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="26" month="12" />
@@ -117,5 +111,4 @@
 		<observanceRule dayOfWeek="1" addDays="1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="2" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/sd/sd.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/sd/sd.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://dlr.sd.gov/holiday_closures.aspx</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,21 +45,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Native Americans Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -66,14 +65,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -82,5 +79,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/tn/tn.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/tn/tn.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://www.tn.gov/about-tn/state-holidays.html</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,21 +11,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -39,14 +34,20 @@
 		</date>
 		<name lang="en">Good Friday</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -55,21 +56,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" validTo="2015-12-31">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -78,14 +76,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2016-01-01">
 		<date>
 			<dateTransformation>
@@ -97,7 +93,6 @@
 		</date>
 		<name lang="en">The Friday after Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -106,5 +101,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/tx/tx.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/tx/tx.xml
@@ -1,66 +1,64 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://comptroller.texas.gov/about/holidays.php</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
 		</date>
 		<name lang="en">New Year's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
 		</date>
 		<name lang="en">Independence Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
 		</date>
 		<name lang="en">Veteran's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -72,26 +70,22 @@
 		</date>
 		<name lang="en">Friday after Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="24" month="12" />
 		</date>
 		<name lang="en">Christmas Eve</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
 		</date>
 		<name lang="en">Christmas Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="26" month="12" />
 		</date>
 		<name lang="en">The Day after Christmas</name>
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/ut/ut.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/ut/ut.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://le.utah.gov/~code/TITLE63G/htm/63G01_030100.htm</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Dr. Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,7 +45,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="24" month="7" />
@@ -52,21 +53,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -75,14 +73,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -91,5 +87,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/va/va.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/va/va.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.vdh.virginia.gov/emergency-medical-services/2016-state-holidays-observed/</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,7 +11,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -25,28 +22,32 @@
 		</date>
 		<name lang="en">Lee-Jackson Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">George Washington Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -55,21 +56,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day &amp; Yorktown Victory Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -78,14 +76,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -97,7 +93,6 @@
 		</date>
 		<name lang="en">Day After Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -106,5 +101,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/vt/vt.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/vt/vt.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://humanresources.vermont.gov/benefits-wellness/holiday-schedule</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,35 +11,38 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">Presidents' Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="2" month="3" nth="1" />
 		</date>
 		<name lang="en">Town Meeting Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -50,7 +51,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="16" month="8" />
@@ -59,14 +59,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -75,14 +73,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -91,13 +87,10 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
-	<!-- Old Holidays -->
 	<holiday validFrom="2011-01-01" validTo="2012-12-31">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/wa/wa.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/wa/wa.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://dor.wa.gov/contact-us/state-holiday-schedule</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King, Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,14 +45,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -59,14 +59,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<dateTransformation>
@@ -78,7 +76,6 @@
 		</date>
 		<name lang="en">Native American Heritage Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -87,5 +84,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/wi/wi.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/wi/wi.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>https://dpm.wi.gov/Pages/How_Do_I/seeStateHolidays.aspx</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -12,21 +10,26 @@
 		<name lang="en">New Year's Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr.'s Birthday</name>
 	</holiday>
-
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -34,21 +37,18 @@
 		<name lang="en">Independence Day</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="24" month="12" />
@@ -57,7 +57,6 @@
 		<observanceRule dayOfWeek="6" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -67,7 +66,6 @@
 		<observanceRule dayOfWeek="7" addDays="2" additionalHoliday="false" />
 		<observanceRule dayOfWeek="1" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="31" month="12" />
@@ -75,5 +73,4 @@
 		<name lang="en">New Year's Eve</name>
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/wv/wv.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/wv/wv.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://www.wvdhhr.org/bph/hsc/Holidays.asp</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,35 +11,38 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr. Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="2%0">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="2" month="5" nth="2" />
 		</date>
 		<name lang="en">Primary Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="20" month="6" />
@@ -50,7 +51,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -59,21 +59,18 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="10" nth="2" />
 		</date>
 		<name lang="en">Columbus Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01" frequency="2%0">
 		<date>
 			<dateTransformation>
@@ -85,7 +82,6 @@
 		</date>
 		<name lang="en">General Election Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -94,14 +90,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2016-01-01">
 		<date>
 			<dateTransformation>
@@ -113,7 +107,6 @@
 		</date>
 		<name lang="en">Day After Thanksgiving</name>
 	</holiday>
-	
 	<holiday validFrom="2013-01-01">
 		<date>
 			<fixedDate day="24" month="12" />
@@ -122,7 +115,6 @@
 		<flag>PART_DAY_HOLIDAY</flag>
 		<note lang="en">One-half day</note>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -131,7 +123,6 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2013-01-01">
 		<date>
 			<fixedDate day="31" month="12" />
@@ -140,8 +131,6 @@
 		<flag>PART_DAY_HOLIDAY</flag>
 		<note lang="en">One-half day</note>
 	</holiday>
-	
-	<!-- Old holidays -->
 	<holiday validFrom="2011-01-01" validTo="2015-12-31">
 		<date>
 			<dateTransformation>
@@ -153,5 +142,4 @@
 		</date>
 		<name lang="en">Lincoln's Day</name>
 	</holiday>
-
 </holidays>

--- a/holiday_library/holiday_defs/public_holiday/usa/wy/wy.xml
+++ b/holiday_library/holiday_defs/public_holiday/usa/wy/wy.xml
@@ -1,10 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="usa">
-
 	<metadata>
 		<reference>http://soswy.state.wy.us/Holiday.aspx</reference>
 	</metadata>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="1" month="1" />
@@ -13,28 +11,32 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="1" nth="3" />
 		</date>
 		<name lang="en">Martin Luther King Jr./WY Equality Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="2" nth="3" />
 		</date>
 		<name lang="en">President's Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="5" nth="last" />
 		</date>
 		<name lang="en">Memorial Day</name>
 	</holiday>
-	
+	<holiday validFrom="2021-06-17">
+		<date>
+			<fixedDate day="19" month="6" />
+		</date>
+		<name lang="en">Juneteenth National Independence Day</name>
+		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
+		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
+	</holiday>
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="4" month="7" />
@@ -43,14 +45,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="1" month="9" nth="1" />
 		</date>
 		<name lang="en">Labor Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="11" month="11" />
@@ -59,14 +59,12 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<nthWeekdayRuleDate dayOfWeek="4" month="11" nth="4" />
 		</date>
 		<name lang="en">Thanksgiving Day</name>
 	</holiday>
-	
 	<holiday validFrom="2011-01-01">
 		<date>
 			<fixedDate day="25" month="12" />
@@ -75,5 +73,4 @@
 		<observanceRule dayOfWeek="6" addDays="-1" additionalHoliday="false" />
 		<observanceRule dayOfWeek="7" addDays="1" additionalHoliday="false" />
 	</holiday>
-
 </holidays>


### PR DESCRIPTION
Juneteenth wasn't present in US public holiday definitions, as currently the API marks dates that fall on it as non-holidays