### PR TITLE
Add 27 December 2022 as public holiday in South Africa

### DIFF
--- a/holiday_library/holiday_defs/public_holiday/zaf/2022.xml
+++ b/holiday_library/holiday_defs/public_holiday/zaf/2022.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="zaf">
+	<metadata>
+		<reference>https://www.gov.za/about-sa/public-holidays</reference>
+	</metadata>
+
+	<holiday validFrom="2022-01-01" validTo="2022-12-31">
+		<date>
+			<fixedDate day="27" month="12" />
+		</date>
+		<name lang="en">Public Holiday</name>
+	</holiday>
+
+</holidays>

--- a/holiday_library/holiday_defs/public_holiday/zaf/2022.xml
+++ b/holiday_library/holiday_defs/public_holiday/zaf/2022.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="zaf">
 	<metadata>
-		<reference>https://www.gov.za/about-sa/public-holidays</reference>
+		<reference>https://www.gov.za/speeches/president-cyril-ramaphosa-declares-27-december-public-holiday-8-dec-2022-0000</reference>
 	</metadata>
 
 	<holiday validFrom="2022-01-01" validTo="2022-12-31">


### PR DESCRIPTION
27 December 2022 was declared a public holiday as Christmas falls on a Sunday.  
https://www.gov.za/about-sa/public-holidays
https://www.gov.za/speeches/president-cyril-ramaphosa-declares-27-december-public-holiday-8-dec-2022-0000