### PR TITLE
UK bank holiday change for 2023

### DIFF
--- a/holiday_library/holiday_defs/public_holiday/gbr/2023.xml
+++ b/holiday_library/holiday_defs/public_holiday/gbr/2023.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="gbr">
+	<metadata>
+		<reference>https://www.gov.uk/bank-holidays</reference>
+	</metadata>
+
+	<holiday validFrom="2023-01-01" validTo="2023-12-31">
+		<date>
+			<fixedDate day="8" month="5" />
+		</date>
+		<name lang="en">Bank holiday for the coronation of King Charles III</name>
+	</holiday>
+
+</holidays>


### PR DESCRIPTION
Additional UK bank holiday on 8 May 2023 for the coronation of King Charles III. Other bank holidays unchanged.