### PR TITLE
Add South Africa 2024 election date

### DIFF
--- a/holiday_library/holiday_defs/public_holiday/zaf/2024.xml
+++ b/holiday_library/holiday_defs/public_holiday/zaf/2024.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="zaf">
+	<metadata>
+		<reference>https://www.gov.za/news/media-statements/electoral-commission-welcomes-announcement-2024-election-date-21-feb-2024</reference>
+	</metadata>
+
+	<holiday validFrom="2024-01-01" validTo="2024-12-31">
+		<date>
+			<fixedDate day="29" month="5" />
+		</date>
+		<name lang="en">Election day</name>
+		<note lang="en">2024 election date</note>
+	</holiday>
+
+</holidays>


### PR DESCRIPTION
https://www.gov.za/news/media-statements/electoral-commission-welcomes-announcement-2024-election-date-21-feb-2024