### PR TITLE
add 2026 World Cup bank holiday in Scotland

### DIFF
--- a/holiday_library/holiday_defs/public_holiday/gbr/sct/2026.xml
+++ b/holiday_library/holiday_defs/public_holiday/gbr/sct/2026.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<holidays xmlns="https://kayaposoft.com/enrico/xsd/1.0" country="gbr">
+	<metadata>
+		<reference>https://www.gov.uk/bank-holidays#scotland</reference>
+	</metadata>
+
+	<holiday validFrom="2026-01-01" validTo="2026-12-31">
+		<date>
+			<fixedDate day="15" month="6" />
+		</date>
+		<name lang="en">World Cup bank holiday</name>
+	</holiday>
+
+</holidays>


### PR DESCRIPTION
Scotland only, not rest of GBR.

No change to existing bank holidays.

https://www.gov.scot/news/world-cup-bank-holiday-confirmed/
https://www.gov.uk/bank-holidays#scotland